### PR TITLE
fix(itsk-select): Исправлено отображение элементов после закрытия селекта

### DIFF
--- a/projects/components/src/component/itsk-select/itsk-select/itsk-select.component.ts
+++ b/projects/components/src/component/itsk-select/itsk-select/itsk-select.component.ts
@@ -301,6 +301,7 @@ export class ItskSelectComponent implements ControlValueAccessor, OnInit {
       if (this.hasSearch) {
         this.elementRef.nativeElement.focus();
         this.searchText$ = '';
+        this.viewItems$ = this.items$ ?? [];
       }
       if (this.searchTextSubscription$) {
         this.searchTextSubscription$.unsubscribe();


### PR DESCRIPTION
Исправлена ошибка, при которой после выбора элемента из отфильтрованного списка повторное открытие выпадающего меню отображало только отфильтрованные значения вместо полного списка.